### PR TITLE
Add proposal cycle dates class

### DIFF
--- a/src/main/java/org/orph2020/pst/common/json/ProposalCycleDates.java
+++ b/src/main/java/org/orph2020/pst/common/json/ProposalCycleDates.java
@@ -1,0 +1,20 @@
+package org.orph2020.pst.common.json;
+
+import java.util.Date;
+
+public class ProposalCycleDates {
+    public String title;
+    public Date submissionDeadline;
+    public Date observationSessionStart;
+    public Date observationSessionEnd;
+
+    public ProposalCycleDates(String title, Date submissionDeadline, Date observationSessionStart, Date observationSessionEnd)
+    {
+        this.title = title;
+        this.submissionDeadline = submissionDeadline;
+        this.observationSessionStart = observationSessionStart;
+        this.observationSessionEnd = observationSessionEnd;
+    }
+
+    public ProposalCycleDates() {}
+}


### PR DESCRIPTION
Add a new class for the dates associated with a proposal cycle.  Part of the solution to [API issue #6](https://github.com/orppst/pst-api-service/issues/6).